### PR TITLE
fix: nullable window & localStorage

### DIFF
--- a/src/utils/convertLocalStorageIntegerToBoolean.ts
+++ b/src/utils/convertLocalStorageIntegerToBoolean.ts
@@ -1,5 +1,7 @@
 const convertLocalStorageIntegerToBoolean = (key: string): boolean => {
-  const localStorageItem = window.localStorage.getItem(key)
+  // 📌 Info:
+  // `window` or `localStorage` are null via SSR
+  const localStorageItem = window?.localStorage?.getItem(key)
   if (localStorageItem !== null) {
     const probablyInteger = parseInt(localStorageItem, 10)
     if (isNaN(probablyInteger)) {


### PR DESCRIPTION
## What

Access to `window` and `localStorage` is now null-safe.

## Why

Our next.js app crashes via SSR because `import VideoPlayer from '@stroeer/stroeer-videoplayer';` implicit calls the code automatically.

## Info testing

Of course I wrote a test for this change. But jest executes all tests in parallel so that this test raises issues regarding the global scope of `window` and `localStorage`. I would recommend to create an abstraction around the `localStorage` stuff.

```ts
describe('null safety', () => {
  beforeEach(() => {
    const savedLocalStorage = window.localStorage
    Object.defineProperty(window, 'localStorage', {
      value: null
    })
    afterEach(() => {
      Object.defineProperty(window, 'localStorage', {
        value: savedLocalStorage
      })
    })
  })

  it('should return false, when `window` or `localStorage` are undefined. This is possible via SSR.', () => {
    expect(convertLocalStorageIntegerToBoolean('foobar')).toBe(false)
  })
})
```