### PR TITLE
VP-59 add some function for endcard to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.5",
+ "version": "0.0.6",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -11,6 +11,14 @@ containerEl.appendChild(videoEl)
 
 const p1 = new StrooerVideoplayer(videoEl)
 
+const playStub = jest
+  .spyOn(window.HTMLMediaElement.prototype, 'play')
+  .mockImplementation()
+
+const loadStub = jest
+  .spyOn(window.HTMLMediaElement.prototype, 'load')
+  .mockImplementation()
+
 it('should return a dataStore for .getDataStore()', () => {
   expect(p1.getDataStore().videoEl).toBe(videoEl)
 })
@@ -256,4 +264,44 @@ it('should deinit the ivad Plugin', () => {
 it('should not deinit the foorbarbaz Plugin', () => {
   const retval = p1.deinitPlugin('foorbarbaz')
   expect(retval).toBe(false)
+})
+
+it('should play video', () => {
+  p1.play()
+  expect(playStub).toHaveBeenCalled()
+  playStub.mockRestore()
+})
+
+it('should load video', () => {
+  p1.load()
+  expect(loadStub).toHaveBeenCalled()
+  loadStub.mockRestore()
+})
+
+it('should set new source to HTML', () => {
+  const sourceArr = [
+    {
+      quality: '1080',
+      label: '1080p',
+      src: 'https://dlc2.t-online.de/s/2021/05/07/20027894-1080p.mp4',
+      type: 'video/mp4'
+    },
+    {
+      quality: '720',
+      label: '720p',
+      src: 'https://dlc2.t-online.de/s/2021/05/07/20027894-720p.mp4',
+      type: 'video/mp4'
+    },
+    {
+      quality: '240',
+      label: '240p',
+      src: 'https://dlc2.t-online.de/s/2021/05/07/20027894-240p.mp4',
+      type: 'video/mp4'
+    }
+  ]
+  p1.setSrc(sourceArr)
+  const videoSources = videoEl.getElementsByTagName('source')
+  for (let i = 0; i < videoSources.length; i++) {
+    expect(videoSources[i].src).toEqual(sourceArr[i].src)
+  }
 })

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -15,6 +15,13 @@ interface IRegisteredUI {
   deinit: Function
 }
 
+interface IVideoSources {
+  src: string
+  type: string
+  quality: string
+  label: string
+}
+
 interface IRegisteredPlugin {
   pluginName: string
   init: Function
@@ -259,6 +266,31 @@ class StrooerVideoplayer {
 
   getDataStore = (): IStrooerVideoplayerDataStore => {
     return this._dataStore
+  }
+
+  play = (): void => {
+    const promise = this._dataStore.videoEl.play()
+    if (promise !== undefined) {
+      promise.then().catch(playPromiseEx => {
+        log('error')(
+          'StrooerVideoplayer',
+          'Handled Play Promise exception',
+          playPromiseEx
+        )
+      })
+    }
+  }
+
+  load = (): void => {
+    this._dataStore.videoEl.load()
+  }
+
+  setSrc = (sources: IVideoSources[]): void => {
+    this._dataStore.videoEl.innerHTML = ''
+    sources.forEach((video) => {
+      this._dataStore.videoEl.innerHTML += `<source src="${video.src}"
+        type="${video.type}" data-quality="${video.quality}" data-label="${video.type}">`
+    })
   }
 }
 


### PR DESCRIPTION
I added some functions that I need in endcard plugin. They're just a simple version, so you can extend them or replace them. 

In endcard I use it for e.g. click on a card --> new video should be played:
```
play = (idx: number): void => {
    ...
    this.videoplayer.setSrc(videoSources)
    this.videoplayer.load()
    this.videoplayer.play()
    this.hide()
  }
```