### PR TITLE
VP-92 add functions for endcard tracking issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.6",
+ "version": "0.0.7",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -337,14 +337,12 @@ it('should call correct functions in replaceAndPlay function', () => {
   p1.load = jest.fn()
   p1.play = jest.fn()
   p1.setEndcardUrl = jest.fn()
-  p1.setAutoplay = jest.fn()
 
   p1.replaceAndPlay(testVideoData)
 
   expect(p1.setSrc).toHaveBeenCalledTimes(1)
   expect(p1.setPosterImage).toHaveBeenCalledTimes(1)
   expect(p1.setEndcardUrl).toHaveBeenCalledTimes(1)
-  expect(p1.setAutoplay).toHaveBeenCalledTimes(1)
   expect(p1.setMetaData).toHaveBeenCalledTimes(1)
   expect(p1.load).toHaveBeenCalledTimes(1)
   expect(p1.play).toHaveBeenCalledTimes(1)

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -19,7 +19,12 @@ const loadStub = jest
   .spyOn(window.HTMLMediaElement.prototype, 'load')
   .mockImplementation()
 
-const testVideoData = { sources: [], poster: 'www.example.de/image.jpg', endpoint: 'www.example.de' }
+const testVideoData = {
+  autoplay: true,
+  sources: [],
+  poster: 'www.example.de/image.jpg',
+  endpoint: 'www.example.de'
+}
 
 it('should return a dataStore for .getDataStore()', () => {
   expect(p1.getDataStore().videoEl).toBe(videoEl)
@@ -337,12 +342,16 @@ it('should call correct functions in replaceAndPlay function', () => {
   p1.load = jest.fn()
   p1.play = jest.fn()
   p1.setEndcardUrl = jest.fn()
+  p1.setAutoplay = jest.fn()
+  p1.setContentVideo = jest.fn()
 
-  p1.replaceAndPlay(testVideoData)
+  p1.replaceAndPlay(testVideoData, true)
 
+  expect(p1.setContentVideo).toHaveBeenCalledTimes(1)
   expect(p1.setSrc).toHaveBeenCalledTimes(1)
   expect(p1.setPosterImage).toHaveBeenCalledTimes(1)
   expect(p1.setEndcardUrl).toHaveBeenCalledTimes(1)
+  expect(p1.setAutoplay).toHaveBeenCalledTimes(1)
   expect(p1.setMetaData).toHaveBeenCalledTimes(1)
   expect(p1.load).toHaveBeenCalledTimes(1)
   expect(p1.play).toHaveBeenCalledTimes(1)

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -319,12 +319,6 @@ it('should set and get poster image', () => {
   expect(retval).toEqual('www.example.de/image.jpg')
 })
 
-it('should set and get endcard url', () => {
-  p1.setEndcardUrl('www.example.de')
-  const retval = p1.getEndcardUrl()
-  expect(retval).toEqual('www.example.de')
-})
-
 it('should set autoplay', () => {
   p1.setAutoplay(false)
   expect(videoEl.dataset.autoplay).toEqual('false')
@@ -341,7 +335,6 @@ it('should call correct functions in replaceAndPlay function', () => {
   p1.setMetaData = jest.fn()
   p1.load = jest.fn()
   p1.play = jest.fn()
-  p1.setEndcardUrl = jest.fn()
   p1.setAutoplay = jest.fn()
   p1.setContentVideo = jest.fn()
 
@@ -350,7 +343,6 @@ it('should call correct functions in replaceAndPlay function', () => {
   expect(p1.setContentVideo).toHaveBeenCalledTimes(1)
   expect(p1.setSrc).toHaveBeenCalledTimes(1)
   expect(p1.setPosterImage).toHaveBeenCalledTimes(1)
-  expect(p1.setEndcardUrl).toHaveBeenCalledTimes(1)
   expect(p1.setAutoplay).toHaveBeenCalledTimes(1)
   expect(p1.setMetaData).toHaveBeenCalledTimes(1)
   expect(p1.load).toHaveBeenCalledTimes(1)

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -308,13 +308,13 @@ it('should set new source to HTML', () => {
   }
 })
 
-it('should should set and get poster image', () => {
+it('should set and get poster image', () => {
   p1.setPosterImage('www.example.de/image.jpg')
   const retval = p1.getPosterImage()
   expect(retval).toEqual('www.example.de/image.jpg')
 })
 
-it('should should set meta data', () => {
+it('should set meta data', () => {
   p1.setMetaData(testVideoData)
   expect(videoEl.dataset.meta).toEqual(JSON.stringify(testVideoData))
 })

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -19,6 +19,8 @@ const loadStub = jest
   .spyOn(window.HTMLMediaElement.prototype, 'load')
   .mockImplementation()
 
+const testVideoData = { sources: [], poster: 'www.example.de/image.jpg' }
+
 it('should return a dataStore for .getDataStore()', () => {
   expect(p1.getDataStore().videoEl).toBe(videoEl)
 })
@@ -304,4 +306,31 @@ it('should set new source to HTML', () => {
   for (let i = 0; i < videoSources.length; i++) {
     expect(videoSources[i].src).toEqual(sourceArr[i].src)
   }
+})
+
+it('should should set and get poster image', () => {
+  p1.setPosterImage('www.example.de/image.jpg')
+  const retval = p1.getPosterImage()
+  expect(retval).toEqual('www.example.de/image.jpg')
+})
+
+it('should should set meta data', () => {
+  p1.setMetaData(testVideoData)
+  expect(videoEl.dataset.meta).toEqual(JSON.stringify(testVideoData))
+})
+
+it('should call correct functions in replaceAndPlay function', () => {
+  p1.setSrc = jest.fn()
+  p1.setPosterImage = jest.fn()
+  p1.setMetaData = jest.fn()
+  p1.load = jest.fn()
+  p1.play = jest.fn()
+
+  p1.replaceAndPlay(testVideoData)
+
+  expect(p1.setSrc).toHaveBeenCalledTimes(1)
+  expect(p1.setPosterImage).toHaveBeenCalledTimes(1)
+  expect(p1.setMetaData).toHaveBeenCalledTimes(1)
+  expect(p1.load).toHaveBeenCalledTimes(1)
+  expect(p1.play).toHaveBeenCalledTimes(1)
 })

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -19,7 +19,7 @@ const loadStub = jest
   .spyOn(window.HTMLMediaElement.prototype, 'load')
   .mockImplementation()
 
-const testVideoData = { sources: [], poster: 'www.example.de/image.jpg' }
+const testVideoData = { sources: [], poster: 'www.example.de/image.jpg', endpoint: 'www.example.de' }
 
 it('should return a dataStore for .getDataStore()', () => {
   expect(p1.getDataStore().videoEl).toBe(videoEl)
@@ -312,6 +312,17 @@ it('should set and get poster image', () => {
   p1.setPosterImage('www.example.de/image.jpg')
   const retval = p1.getPosterImage()
   expect(retval).toEqual('www.example.de/image.jpg')
+})
+
+it('should set and get endcard url', () => {
+  p1.setEndcardUrl('www.example.de')
+  const retval = p1.getEndcardUrl()
+  expect(retval).toEqual('www.example.de')
+})
+
+it('should set autoplay', () => {
+  p1.setAutoplay(false)
+  expect(videoEl.dataset.autoplay).toEqual('false')
 })
 
 it('should set meta data', () => {

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -336,11 +336,15 @@ it('should call correct functions in replaceAndPlay function', () => {
   p1.setMetaData = jest.fn()
   p1.load = jest.fn()
   p1.play = jest.fn()
+  p1.setEndcardUrl = jest.fn()
+  p1.setAutoplay = jest.fn()
 
   p1.replaceAndPlay(testVideoData)
 
   expect(p1.setSrc).toHaveBeenCalledTimes(1)
   expect(p1.setPosterImage).toHaveBeenCalledTimes(1)
+  expect(p1.setEndcardUrl).toHaveBeenCalledTimes(1)
+  expect(p1.setAutoplay).toHaveBeenCalledTimes(1)
   expect(p1.setMetaData).toHaveBeenCalledTimes(1)
   expect(p1.load).toHaveBeenCalledTimes(1)
   expect(p1.play).toHaveBeenCalledTimes(1)

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -18,7 +18,6 @@ interface IRegisteredUI {
 interface IVideoData {
   sources: IVideoSources[]
   poster: string
-  endpoint: string
   // add more if needed
 }
 
@@ -292,15 +291,6 @@ class StrooerVideoplayer {
     this._dataStore.videoEl.load()
   }
 
-  getEndcardUrl = (): string => {
-    const url = this._dataStore.videoEl.dataset.endcardUrl
-    return url !== undefined ? url : ''
-  }
-
-  setEndcardUrl = (url: string): void => {
-    this._dataStore.videoEl.dataset.endcardUrl = url
-  }
-
   setAutoplay = (autoplay: boolean): void => {
     this._dataStore.videoEl.dataset.autoplay = String(autoplay)
   }
@@ -330,7 +320,6 @@ class StrooerVideoplayer {
     this.setContentVideo()
     this.setSrc(videoData.sources)
     this.setPosterImage(videoData.poster)
-    this.setEndcardUrl(videoData.endpoint)
     this.setAutoplay(autoplay)
     this.setMetaData(videoData)
     this.load()

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -326,10 +326,12 @@ class StrooerVideoplayer {
     this._dataStore.videoEl.dataset.meta = JSON.stringify(videoData)
   }
 
-  replaceAndPlay = (videoData: IVideoData): void => {
+  replaceAndPlay = (videoData: IVideoData, autoplay: boolean = false): void => {
+    this.setContentVideo()
     this.setSrc(videoData.sources)
     this.setPosterImage(videoData.poster)
     this.setEndcardUrl(videoData.endpoint)
+    this.setAutoplay(autoplay)
     this.setMetaData(videoData)
     this.load()
     this.play()

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -330,7 +330,6 @@ class StrooerVideoplayer {
     this.setSrc(videoData.sources)
     this.setPosterImage(videoData.poster)
     this.setEndcardUrl(videoData.endpoint)
-    this.setAutoplay(false)
     this.setMetaData(videoData)
     this.load()
     this.play()

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -15,6 +15,12 @@ interface IRegisteredUI {
   deinit: Function
 }
 
+interface IVideoData {
+  sources: IVideoSources[]
+  poster: string
+  // add more if needed
+}
+
 interface IVideoSources {
   src: string
   type: string
@@ -285,12 +291,33 @@ class StrooerVideoplayer {
     this._dataStore.videoEl.load()
   }
 
+  getPosterImage = (): string => {
+    const poster = this._dataStore.videoEl.getAttribute('poster')
+    return poster !== null ? poster : ''
+  }
+
+  setPosterImage = (url: string): void => {
+    this._dataStore.videoEl.setAttribute('poster', url)
+  }
+
   setSrc = (sources: IVideoSources[]): void => {
     this._dataStore.videoEl.innerHTML = ''
     sources.forEach((video) => {
       this._dataStore.videoEl.innerHTML += `<source src="${video.src}"
         type="${video.type}" data-quality="${video.quality}" data-label="${video.type}">`
     })
+  }
+
+  setMetaData = (videoData: IVideoData): void => {
+    this._dataStore.videoEl.dataset.meta = JSON.stringify(videoData)
+  }
+
+  replaceAndPlay = (videoData: IVideoData): void => {
+    this.setSrc(videoData.sources)
+    this.setPosterImage(videoData.poster)
+    this.setMetaData(videoData)
+    this.load()
+    this.play()
   }
 }
 

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -18,6 +18,7 @@ interface IRegisteredUI {
 interface IVideoData {
   sources: IVideoSources[]
   poster: string
+  endpoint: string
   // add more if needed
 }
 
@@ -291,6 +292,19 @@ class StrooerVideoplayer {
     this._dataStore.videoEl.load()
   }
 
+  getEndcardUrl = (): string => {
+    const url = this._dataStore.videoEl.dataset.endcardUrl
+    return url !== undefined ? url : ''
+  }
+
+  setEndcardUrl = (url: string): void => {
+    this._dataStore.videoEl.dataset.endcardUrl = url
+  }
+
+  setAutoplay = (autoplay: boolean): void => {
+    this._dataStore.videoEl.dataset.autoplay = String(autoplay)
+  }
+
   getPosterImage = (): string => {
     const poster = this._dataStore.videoEl.getAttribute('poster')
     return poster !== null ? poster : ''
@@ -315,6 +329,8 @@ class StrooerVideoplayer {
   replaceAndPlay = (videoData: IVideoData): void => {
     this.setSrc(videoData.sources)
     this.setPosterImage(videoData.poster)
+    this.setEndcardUrl(videoData.endpoint)
+    this.setAutoplay(false)
     this.setMetaData(videoData)
     this.load()
     this.play()


### PR DESCRIPTION
- We need to set all video data as data attribute (setMetaData()) because of tracking issues.

- We have more than one video on a page and we also have a video gallery on giga.de homepage, where videos should be replaced and play by click. I also need the replace and play function in the endcard, so in videoplayer is the global place for this function. 

- added getPosterImage() and setPosterImage()
- added setAutoplay()