### PR TITLE
Feat/make datastore hls publicly accessible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.8",
+ "version": "0.0.9",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -281,6 +281,10 @@ class StrooerVideoplayer {
     return this._dataStore
   }
 
+  getHls = (): HlsJs | null => {
+    return this._dataStore.hls
+  }
+
   getHlsJs = (): typeof HlsJs => {
     return HlsJs
   }
@@ -327,9 +331,9 @@ class StrooerVideoplayer {
       hls.loadSource(videoSource.src)
       hls.attachMedia(videoEl)
 
-      hls.on(HlsJs.Events.ERROR, (event, data) => {
+      hls.on(HlsJs.Events.ERROR, (event: any, data: any) => {
         console.log(event, data)
-        if (data.fatal) {
+        if (data.fatal !== undefined) {
           switch (data.type) {
             case HlsJs.ErrorTypes.NETWORK_ERROR:
               // try to recover network error


### PR DESCRIPTION
I need a way to access the internal hls object,
so I created a public method `getHls()` which returns `null` or
the instance of `hls`.