### PR TITLE
stroeervpInitialized event

### DIFF
--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -59,6 +59,16 @@ it('should not log when logging is explicitly disabled', () => {
   expect(StrooerVideoplayer.log()('info', 1)).toBe(false)
 })
 
+it('should trigger stroeervpInitialized', () => {
+  const videoEl = document.createElement('video')
+  let triggered = false
+  videoEl.addEventListener('stroeervpInitialized', () => {
+    triggered = true
+  })
+  new StrooerVideoplayer(videoEl) // eslint-disable-line no-new
+  expect(triggered).toBe(true)
+})
+
 it('should trigger firstPlay', () => {
   let triggered = false
   videoEl.addEventListener('firstPlay', () => {

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -59,10 +59,10 @@ it('should not log when logging is explicitly disabled', () => {
   expect(StrooerVideoplayer.log()('info', 1)).toBe(false)
 })
 
-it('should trigger stroeervpInitialized', () => {
+it('should trigger stroeer-videoplayer:initialized', () => {
   const videoEl = document.createElement('video')
   let triggered = false
-  videoEl.addEventListener('stroeervpInitialized', () => {
+  videoEl.addEventListener('stroeer-videoplayer:initialized', () => {
     triggered = true
   })
   new StrooerVideoplayer(videoEl) // eslint-disable-line no-new

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -96,7 +96,7 @@ class StroeerVideoplayer {
     if (videoEl.getAttribute('data-stroeervp-initialized') === null) {
       videoEl.setAttribute('data-stroeervp-initialized', '1')
 
-      videoEl.dispatchEvent(new Event('stroeervpInitialized'))
+      videoEl.dispatchEvent(new Event('stroeer-videoplayer:initialized'))
 
       if (ds.videoEl.parentNode !== null) {
         ds.videoEl.parentNode.insertBefore(ds.rootEl, ds.videoEl)

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -96,6 +96,8 @@ class StroeerVideoplayer {
     if (videoEl.getAttribute('data-stroeervp-initialized') === null) {
       videoEl.setAttribute('data-stroeervp-initialized', '1')
 
+      videoEl.dispatchEvent(new Event('stroeervpInitialized'))
+
       if (ds.videoEl.parentNode !== null) {
         ds.videoEl.parentNode.insertBefore(ds.rootEl, ds.videoEl)
         ds.containmentEl.appendChild(ds.uiEl)


### PR DESCRIPTION
BUZZ-1177 braucht ein event wenn der player initialisiert wird. Ich würde das gerne im player feuern und nicht bei uns. aber sag gerne ob du das für sinnvoll hälst.

ausserdem, der name von dem event: "stroeervpInitialized" — ich finde den selber nicht gut, vielleicht hast du eine idee dir dir besser gefällt? dann würde ich das noch ändern