### PR TITLE
[draft] Add named exports

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default [{
   input: 'src/StroeerVideoplayer.ts',
   output: {
     file: 'dist/StroeerVideoplayer.umd.js',
-    exports: 'default',
+    exports: 'named',
     format: 'umd',
     name: 'StroeerVideoplayer',
     sourcemap: true
@@ -25,7 +25,9 @@ export default [{
   output: [
     {
       file: pkg.main,
-      format: 'cjs'
+      exports: 'named',
+      format: 'cjs',
+      sourcemap: true
     }
   ],
   plugins: [
@@ -40,7 +42,8 @@ export default [{
   output: [
     {
       file: pkg.module,
-      format: 'es'
+      format: 'es',
+      sourcemap: true
     }
   ],
   plugins: [

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -480,4 +480,5 @@ class StroeerVideoplayer {
   }
 }
 
+export { StroeerVideoplayer }
 export default StroeerVideoplayer


### PR DESCRIPTION
Wie in #13 gewünscht wollte ich jetzt named exports "aktivieren", aber irgendwie funktioniert das nicht wie von mir gewollt/verstanden.

Rollup meckert dann die ganze Zeit, wenn ich folgendes mache:

```
  output: {
    file: 'dist/StroeerVideoplayer.umd.js',
    exports: 'default',
    format: 'umd',
    name: 'StroeerVideoplayer',
    sourcemap: true
  },
```

Wenn ich stattdessn dann `exports` aendere in `named`, also so:

```
  output: {
    file: 'dist/StroeerVideoplayer.umd.js',
    exports: 'name',
    format: 'umd',
    name: 'StroeerVideoplayer',
    sourcemap: true
  },

```

dann gehts, dann ist allerdings im `umd` bundle dann folgendes im window object:

`window.StroeerVideoplayer.StroeerVideoplayer` und `window.StroeerVideoplayer.default`... das ist irgendwie doof.

Ich hatte das so verstanden, dass ich dann z.B. bei dem `umd` Bundle weiterhin ganz normal das `window.StroeerVideoplayer` habe und bei den anderen Bundles mit Named exports dann einfach das Object kommt also `{ StroeerVideoplayer }`.

Ich hatte auch schon überlegt eine zusätzliche Datei anzulegen als Einstiegspunkt für Rollup und das `umd` Bundle, wo ich dann nur `export default StroeerVideoplayer mache`; das fühlt sich aber irgendwie wie ein Hack an; aber vielleicht gehts auch nur so.

Ich brauche auf jedenfall Hilfe und/oder Anregeungen :)

Vielleicht kann @bobaaaaa hier helfen :+1: 