### PR TITLE
🐛 Fix replaceAndPlay method with autoStartLoad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "2.0.0",
+ "version": "2.0.1",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -528,6 +528,7 @@ class StroeerVideoplayer {
     this.setAutoplay(autoplay)
     this.setMetaData(videoData)
     this.loadStreamSource()
+    this._dataStore.hls?.startLoad()
     this.play()
   }
 }


### PR DESCRIPTION
When `autoStartLoad` is set to `false` (our default):

An explicit API call (`hls.startLoad()`) will
be needed to start quality level/fragment loading.