### PR TITLE
🐛 Load `<source>` via `data-src` attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "3.2.0",
+ "version": "4.0.0",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",

--- a/src/StroeerVideoplayer.test.ts
+++ b/src/StroeerVideoplayer.test.ts
@@ -357,8 +357,7 @@ it('should play video', () => {
 it('should set new source to HTML', () => {
   const src = 'https://lx57.spieletips.de/977412104/playlist.m3u8'
   p1.setSrc(src)
-  const videoSources = videoEl.getElementsByTagName('source')
-  expect(videoSources[0].src).toEqual(src)
+  expect(videoEl.dataset.src).toEqual(src)
 })
 
 it('should set and get poster image', () => {

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -394,11 +394,11 @@ class StroeerVideoplayer {
 
   loadStreamSource = (): void => {
     const videoEl = this._dataStore.videoEl
-    const videoSource = videoEl.querySelector('source')
+    const videoSource = videoEl.dataset.src as string
     const canPlayNativeHls = videoEl.canPlayType('application/vnd.apple.mpegurl') === 'probably' ||
       videoEl.canPlayType('application/vnd.apple.mpegurl') === 'maybe'
 
-    if (videoSource === null) return
+    if (videoSource === '') return
 
     if (HlsJs.isSupported()) {
       if (this._dataStore.hls !== null) {
@@ -411,7 +411,7 @@ class StroeerVideoplayer {
         videoEl.dispatchEvent(new CustomEvent('hlsLevelSwitched', { detail: level }))
       })
       this._dataStore.hls = hls
-      hls.loadSource(videoSource.src)
+      hls.loadSource(videoSource)
       hls.attachMedia(videoEl)
 
       hls.on(HlsJs.Events.ERROR, (event: any, data: any) => {
@@ -455,6 +455,7 @@ class StroeerVideoplayer {
         }
       })
     } else if (canPlayNativeHls) {
+      videoEl.src = videoSource
       // Fallback for native HLS
       // We need to check the manifest response code manually
       window.fetch(this.getSource(), { mode: 'cors', cache: 'no-cache' })
@@ -502,8 +503,7 @@ class StroeerVideoplayer {
 
   setSrc = (playlist: string): void => {
     const videoEl = this._dataStore.videoEl
-    videoEl.innerHTML = `<source src="${playlist}" type="application/x-mpegURL">`
-    videoEl.load()
+    videoEl.dataset.src = playlist
     videoEl.currentTime = 0
   }
 


### PR DESCRIPTION
Previously we had a html markup like this:

```html
<video>
  <source src="https://example.com/manifest.m3u8">
</video>
```

This caused native players to immediately start fetching the manifest file. Which resulted in a race-condition on Google Chrome on Android on t-online.de.

When Google Chrome on Android on t-online fetched the manifest before our js (hls.js) kicked in, everything broke down, because the request was cached and the cached request (made via the native browser functionality) had no cors header present.

Now, we load an empty `<video>` tag with a `data-src` attached to it, like so:

```html
<video data-src="https://example.com/manifest.m3u8"></video>
```

This prevents the native browsers to start preloading the manifest file.

This is pretty much 100% the approach that is shown in the example of hls.js:

https://hls-js.netlify.app/demo/basic-usage

```html
<html>
  <head>
    <title>Hls.js demo - basic usage</title>
  </head>

  <body>
    <script src="../dist/hls.js"></script>

    <center>
      <h1>Hls.js demo - basic usage</h1>
      <video height="600" id="video" controls></video>
    </center>

    <script>
      var video = document.getElementById('video');
      if (Hls.isSupported()) {
        var hls = new Hls({
          debug: true,
        });
        hls.loadSource('https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8');
        hls.attachMedia(video);
        hls.on(Hls.Events.MEDIA_ATTACHED, function () {
          video.muted = true;
          video.play();
        });
      }
      // hls.js is not supported on platforms that do not have Media Source Extensions (MSE) enabled.
      // When the browser has built-in HLS support (check using `canPlayType`), we can provide an HLS manifest (i.e. .m3u8 URL) directly to the video element through the `src` property.
      // This is using the built-in support of the plain video element, without using hls.js.
      else if (video.canPlayType('application/vnd.apple.mpegurl')) {
        video.src = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
        video.addEventListener('canplay', function () {
          video.play();
        });
      }
    </script>
  </body>
</html>
```