### PR TITLE
✨ hlsConfig set ignoreDevicePixelRatio to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "4.1.0",
+ "version": "4.2.0",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",

--- a/src/StroeerVideoplayer.ts
+++ b/src/StroeerVideoplayer.ts
@@ -113,6 +113,7 @@ class StroeerVideoplayer {
         maxBufferLength: 10,
         capLevelToPlayerSize: true,
         autoStartLoad: false,
+        ignoreDevicePixelRatio: true,
         ...hlsConfig
       }
     }


### PR DESCRIPTION
Set our custom `hlsConfig` `ignoreDevicePixelRatio` to `true`.

See: https://github.com/video-dev/hls.js/blob/master/docs/API.md#ignoredevicepixelratio