### PR TITLE
added log of error recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
- "version": "4.2.0",
+ "version": "4.2.1",
  "name": "@stroeer/stroeer-videoplayer",
  "description": "Ströer Videoplayer Framework",
  "main": "dist/StroeerVideoplayer.cjs.js",


### PR DESCRIPTION
- added a semaphore to the player, when an error happens and is logged
- on a successful BUFFER_APPEND event when semaphore is present, we can assume that the error has recovered
- in this case we log ERROR_RECOVERED and remove semaphore